### PR TITLE
fix: mistral tool choice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ build-package:
 	if [ -d "dist" ]; then rm -rf dist; fi
 	if [ -d "build" ]; then rm -rf build; fi
 	if [ -d "jaims_py.egg-info" ]; then rm -rf jaims_py.egg-info; fi
+	pip install setuptools wheel twine 
 	python setup.py sdist bdist_wheel
 
 deploy: build-package

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,6 @@ Here I track the next features and improvements that I plan to implement in the 
 - Improve Docs
 - Add Logging
 - Add Anthropic support
-- Add Mistral support
 - Add VLLM support
 - Improve Tests
 - Configure CI tests and deployment with Github Actions

--- a/examples/adapters_mistral_example.py
+++ b/examples/adapters_mistral_example.py
@@ -78,7 +78,7 @@ def main():
 
     agent = create_jaims_mistral(
         kwargs=JAImsMistralKWArgs(
-            model="mistral-small-latest",
+            model="mistral-large-latest",
             stream=stream,
         ),
         transaction_storage=FileTransactionStorage(),

--- a/examples/adapters_openai_example.py
+++ b/examples/adapters_openai_example.py
@@ -2,9 +2,7 @@ import json
 import os
 import time
 from jaims import (
-    JAImsFunctionTool,
     JAImsDefaultHistoryManager,
-    JAImsFunctionToolDescriptor,
     JAImsMessage,
     jaimsfunctiontool,
 )

--- a/jaims/adapters/google_generative_ai_adapter/adapter.py
+++ b/jaims/adapters/google_generative_ai_adapter/adapter.py
@@ -23,7 +23,6 @@ from google.generativeai import GenerativeModel
 from google.generativeai.types import content_types
 from google.generativeai.types import generation_types
 import google.ai.generativelanguage as glm
-import jsonref
 
 
 class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
@@ -44,8 +43,8 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
 
     def call(
         self,
-        messages: List[JAImsMessage],
-        tools: List[JAImsFunctionTool],
+        messages: Optional[List[JAImsMessage]] = None,
+        tools: Optional[List[JAImsFunctionTool]] = None,
         tool_constraints: Optional[List[str]] = None,
     ) -> JAImsMessage:
         response = self.__get_gemini_response(messages, tools, tool_constraints)
@@ -54,8 +53,8 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
 
     def call_streaming(
         self,
-        messages: List[JAImsMessage],
-        tools: List[JAImsFunctionTool],
+        messages: Optional[List[JAImsMessage]] = None,
+        tools: Optional[List[JAImsFunctionTool]] = None,
         tool_constraints: Optional[List[str]] = None,
     ) -> Generator[JAImsStreamingMessage, None, None]:
         response = self.__get_gemini_response(
@@ -77,8 +76,12 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
             return "model"
 
     def __jaims_tools_to_gemini(
-        self, jaims_tools: List[JAImsFunctionTool]
-    ) -> List[content_types.Tool]:
+        self, jaims_tools: Optional[List[JAImsFunctionTool]] = None
+    ) -> Optional[List[content_types.Tool]]:
+
+        if not jaims_tools:
+            return None
+
         function_declarations = []
         for jaims_tool in jaims_tools:
             function_declarations.append(
@@ -189,8 +192,8 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
 
     def __get_gemini_response(
         self,
-        messages: List[JAImsMessage],
-        tools: List[JAImsFunctionTool],
+        messages: Optional[List[JAImsMessage]] = None,
+        tools: Optional[List[JAImsFunctionTool]] = None,
         tool_constraints: Optional[List[str]] = None,
         stream: bool = False,
     ):
@@ -213,12 +216,12 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
 
         def call_gemini():
             system_instruction, gemini_messages = self.__jaims_messages_to_gemini(
-                messages
+                messages or []
             )
-            gemini_tools = self.__jaims_tools_to_gemini(tools) if tools else None
+            gemini_tools = self.__jaims_tools_to_gemini(tools)
 
             tool_config = None
-            if tool_constraints and tools:
+            if tool_constraints and gemini_tools:
                 tool_config = content_types.to_tool_config(
                     {
                         "function_calling_config": {

--- a/jaims/adapters/google_generative_ai_adapter/adapter.py
+++ b/jaims/adapters/google_generative_ai_adapter/adapter.py
@@ -81,13 +81,14 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
     ) -> List[content_types.Tool]:
         function_declarations = []
         for jaims_tool in jaims_tools:
-
             function_declarations.append(
                 content_types.FunctionDeclaration(
                     name=jaims_tool.descriptor.name,
                     description=jaims_tool.descriptor.description,
                     parameters=jaims_tool.descriptor.json_schema(
-                        remove_any_of=True, dereference=True
+                        remove_any_of=True,
+                        dereference=True,
+                        remove_all_of=True,
                     ),
                 ),
             )
@@ -193,9 +194,7 @@ class JAImsGoogleGenerativeAIAdapter(JAImsLLMInterface):
         tool_constraints: Optional[List[str]] = None,
         stream: bool = False,
     ):
-
         def handle_gemini_error(error):
-
             # From: https://ai.google.dev/gemini-api/docs/troubleshooting
             # 400	INVALID_ARGUMENT	The request body is malformed.	Check the API reference for request format, examples, and supported versions. Using features from a newer API version with an older endpoint can cause errors.
             # 403	PERMISSION_DENIED	Your API key doesn't have the required permissions.	Check that your API key is set and has the right access.

--- a/jaims/adapters/mistral_adapter/adapter.py
+++ b/jaims/adapters/mistral_adapter/adapter.py
@@ -202,7 +202,7 @@ class JAImsMistralAdapter(JAImsLLMInterface):
 
             tool_choice = "auto"
             if tool_constraints:
-                if len(tool_constraints) > 1:
+                if len(tool_constraints) >= 1:
                     tool_choice = "any"
                 else:
                     tool_choice = "none"

--- a/jaims/adapters/mistral_adapter/adapter.py
+++ b/jaims/adapters/mistral_adapter/adapter.py
@@ -218,7 +218,11 @@ class JAImsMistralAdapter(JAImsLLMInterface):
         tools: List[JAImsFunctionTool],
         tool_constraints: Optional[List[str]] = None,
     ) -> JAImsMessage:
-        args = self.__get_args(messages, tools)
+        args = self.__get_args(
+            messages=messages,
+            tools=tools,
+            tool_constraints=tool_constraints,
+        )
         response = self.___get_mistral_response(args, self.options)
         assert isinstance(response, ChatCompletionResponse)
         if self.transaction_storage:

--- a/jaims/adapters/mistral_adapter/adapter.py
+++ b/jaims/adapters/mistral_adapter/adapter.py
@@ -200,7 +200,13 @@ class JAImsMistralAdapter(JAImsLLMInterface):
         if tools:
             mistral_tools = self.__jaims_tools_to_mistral(tools)
 
-            tool_choice = args.get("tool_choice", "auto")
+            tool_choice = "auto"
+            if tool_constraints:
+                if len(tool_constraints) > 1:
+                    tool_choice = "any"
+                else:
+                    tool_choice = "none"
+
             args["tools"] = mistral_tools
             args["tool_choice"] = tool_choice
 

--- a/jaims/adapters/mistral_adapter/factory.py
+++ b/jaims/adapters/mistral_adapter/factory.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from ...agent import JAImsAgent
 from ...entities import JAImsFunctionTool, JAImsOptions
 from ...interfaces import JAImsHistoryManager, JAImsToolManager
@@ -17,12 +17,16 @@ def create_jaims_mistral(
     history_manager: Optional[JAImsHistoryManager] = None,
     tool_manager: Optional[JAImsToolManager] = None,
     tools: Optional[List[JAImsFunctionTool]] = None,
+    kwargs_messages_behavior: Literal["append", "replace"] = "append",
+    kwargs_tools_behavior: Literal["append", "replace"] = "append",
 ) -> JAImsAgent:
     adapter = JAImsMistralAdapter(
         api_key=api_key,
         options=options,
         kwargs=kwargs,
         transaction_storage=transaction_storage,
+        kwargs_messages_behavior=kwargs_messages_behavior,
+        kwargs_tools_behavior=kwargs_tools_behavior,
     )
 
     agent = JAImsAgent(

--- a/jaims/adapters/openai_adapter/factory.py
+++ b/jaims/adapters/openai_adapter/factory.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Literal
 from ...agent import JAImsAgent
-from ...entities import JAImsFunctionTool, JAImsOptions, JAImsLLMConfig
+from ...entities import JAImsFunctionTool, JAImsOptions
 from ...interfaces import JAImsHistoryManager, JAImsToolManager
 from .adapter import (
     JAImsOpenaiAdapter,
@@ -17,6 +17,8 @@ def create_jaims_openai(
     history_manager: Optional[JAImsHistoryManager] = None,
     tool_manager: Optional[JAImsToolManager] = None,
     tools: Optional[List[JAImsFunctionTool]] = None,
+    kwargs_messages_behavior: Literal["append", "replace"] = "append",
+    kwargs_tools_behavior: Literal["append", "replace"] = "append",
 ) -> JAImsAgent:
 
     adapter = JAImsOpenaiAdapter(
@@ -24,6 +26,8 @@ def create_jaims_openai(
         options=options,
         kwargs=kwargs,
         transaction_storage=transaction_storage,
+        kwargs_messages_behavior=kwargs_messages_behavior,
+        kwargs_tools_behavior=kwargs_tools_behavior,
     )
 
     agent = JAImsAgent(

--- a/jaims/interfaces.py
+++ b/jaims/interfaces.py
@@ -34,17 +34,17 @@ class JAImsLLMInterface(ABC):
     @abstractmethod
     def call(
         self,
-        messages: List[JAImsMessage],
-        tools: List[JAImsFunctionTool],
+        messages: Optional[List[JAImsMessage]] = None,
+        tools: Optional[List[JAImsFunctionTool]] = None,
         tool_constraints: Optional[List[str]] = None,
     ) -> JAImsMessage:
         """
         Executes the language learning model on a list of messages and tools.
 
         Args:
-            messages: A list of JAImsMessage objects representing the input messages.
-            tools: A list of JAImsFunctionTool objects representing the tools to be applied.
-            tool_constraints: An optional list of tool constraints.
+            messages: A list of JAImsMessage objects representing the input messages. Defaults to None.
+            tools: A list of JAImsFunctionTool objects representing the tools to be applied. Defaults to None.
+            tool_constraints: An optional list of tool constraints. Defaults to None.
 
         Returns:
             A JAImsMessage object representing the output message.
@@ -57,17 +57,17 @@ class JAImsLLMInterface(ABC):
     @abstractmethod
     def call_streaming(
         self,
-        messages: List[JAImsMessage],
-        tools: List[JAImsFunctionTool],
+        messages: Optional[List[JAImsMessage]] = None,
+        tools: Optional[List[JAImsFunctionTool]] = None,
         tool_constraints: Optional[List[str]] = None,
     ) -> Generator[JAImsStreamingMessage, None, None]:
         """
         Executes the language learning model on a list of messages and tools in a streaming fashion.
 
         Args:
-            messages: A list of JAImsMessage objects representing the input messages.
-            tools: A list of JAImsFunctionTool objects representing the tools to be applied.
-            tool_constraints: An optional list of tool constraints.
+            messages: A list of JAImsMessage objects representing the input messages. Defaults to None.
+            tools: A list of JAImsFunctionTool objects representing the tools to be applied. Defaults to None.
+            tool_constraints: An optional list of tool constraints. Defaults to None.
 
         Yields:
             A JAImsStreamingMessage object representing the output message.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("requirements-mistral.txt") as f:
 
 setup(
     name="jaims-py",
-    version="2.0.0-beta.13",
+    version="2.0.0-beta.14",
     packages=find_packages(),
     description="A Python package for creating LLM powered, agentic, platform agnostic software.",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("requirements-mistral.txt") as f:
 
 setup(
     name="jaims-py",
-    version="2.0.0-beta.12",
+    version="2.0.0-beta.13",
     packages=find_packages(),
     description="A Python package for creating LLM powered, agentic, platform agnostic software.",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("requirements-mistral.txt") as f:
 
 setup(
     name="jaims-py",
-    version="2.0.0-beta.11",
+    version="2.0.0-beta.12",
     packages=find_packages(),
     description="A Python package for creating LLM powered, agentic, platform agnostic software.",
     long_description=open("README.md").read(),


### PR DESCRIPTION
Fixes the mistral tool choice restricting the options to `any`,  `auto` and `none` as [mentioned in their docs](https://docs.mistral.ai/capabilities/function_calling/#tool_choice)